### PR TITLE
Support both 2-tuple args and kwargs in emitter decorator.

### DIFF
--- a/axopy/messaging/decorators.py
+++ b/axopy/messaging/decorators.py
@@ -7,8 +7,9 @@ if isinstance(settings.messaging_backend, str):
     settings.messaging_backend = mod.emitter
 
 class emitter(object):
-    def __init__(self, **data_format):
-        self.data_format = data_format
+    def __init__(self, *args, **kwargs):
+        self.data_format = list(args)
+        self.data_format.extend(kwargs.items())
 
     def __call__(self, function):
         return settings.messaging_backend(function, self.data_format)

--- a/axopy/messaging/qt.py
+++ b/axopy/messaging/qt.py
@@ -15,6 +15,6 @@ class _QtEmitterBase(BaseEmitter, QObject):
 
 
 def emitter(function, data_format):
-    cls = type('QtEmitter', (_QtEmitterBase,),
-               dict(signal=pyqtSignal(*data_format.values())))
+    _, types = zip(*data_format)
+    cls = type('QtEmitter', (_QtEmitterBase,), dict(signal=pyqtSignal(*types)))
     return cls(function, data_format)

--- a/axopy/streams/pytables.py
+++ b/axopy/streams/pytables.py
@@ -14,7 +14,7 @@ class PyTablesSink(object):
 
     def __call__(self, *args):
         row = self.table.row
-        for arg, (colname, coltype) in zip(args, self.data_format.items()):
+        for arg, (colname, coltype) in zip(args, self.data_format):
             row[colname] = arg
         row.append()
         self.table.flush()
@@ -23,17 +23,18 @@ class PyTablesSink(object):
 def format_to_description(data_format):
     """Converts a data format specification to a PyTables description.
 
-    The data format is a dictionary of `var_name: var_dtype` pairs, where
-    `var_name` is a string and `var_dtype` is the data type for the column. If
-    `var_dtype` is a regular Python type (e.g. `float`, `int`, etc.), it is
-    converted to a numpy dtype via `numpy.dtype`. If it is a numpy dtype, it is
-    just passed along to PyTables `Col.from_dtype` to create the column.
+    The data format is a list of 2-tuples with `(var_name, var_dtype)` pairs,
+    where `var_name` is a string and `var_dtype` is the data type for the
+    column. If `var_dtype` is a regular Python type (e.g. `float`, `int`,
+    etc.), it is converted to a numpy dtype via `numpy.dtype`. If it is a numpy
+    dtype, it is just passed along to PyTables `Col.from_dtype` to create the
+    column.
 
     The output is a PyTables `Description` object that can be used to create a
     table.
     """
     desc = {}
-    for i, (colname, coltype) in enumerate(data_format.items()):
+    for i, (colname, coltype) in enumerate(data_format):
         if isinstance(coltype, numpy.dtype):
             dtype = coltype
         else:

--- a/tests/messaging_blocks.py
+++ b/tests/messaging_blocks.py
@@ -20,17 +20,25 @@ class RelayBlock(object):
 
 
 class ComplicatedBlock(object):
-    """Block with a more complicated emitter signature."""
+    """Block with more complicated emitter signatures."""
 
     def __init__(self):
         self.coords = None
 
     @emitter(index=int, coords=tuple, height=float)
-    def emitter(self, i, c, h):
+    def dict_emitter(self, i, c, h):
+        return i, c, h
+
+    @emitter(('index', int), ('coords', tuple), ('height', float))
+    def tuple_emitter(self, i, c, h):
+        return i, c, h
+
+    @emitter(('index', int), coords=tuple, height=float)
+    def mixed_emitter(self, i, c, h):
         return i, c, h
 
     @receiver
-    def receiver(self, i, c, h):
+    def set_coords(self, i, c, h):
         self.coords = c
 
 

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,3 +1,4 @@
+import sys
 import importlib
 import pytest
 
@@ -64,9 +65,26 @@ def test_receiver_connect(memblock, relayblock):
 
 def test_multidata(complicatedblock):
     """Ensure multiple things can be emitted at once."""
-    complicatedblock.emitter.connect(complicatedblock.receiver)
-    complicatedblock.emitter(4, (4.2, 2.8), 9.8)
+    # emitter data format specified as tuples
+    complicatedblock.tuple_emitter.connect(complicatedblock.set_coords)
+    complicatedblock.tuple_emitter(4, (2.1, 6.2), 42.1)
+    assert complicatedblock.coords == (2.1, 6.2)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6),
+                    reason="kwarg emitter format requires Python 3.6+")
+def test_emitter_formats(complicatedblock):
+    """Ensure newer data formats work for Python 3.6+."""
+    # emitter data format specified as multiple kwargs
+    complicatedblock.dict_emitter.connect(complicatedblock.set_coords)
+    complicatedblock.dict_emitter(4, (4.2, 2.8), 9.8)
     assert complicatedblock.coords == (4.2, 2.8)
+
+    # emitter data format specified with mixture of args and kwargs
+    complicatedblock.mixed_emitter.connect(complicatedblock.set_coords)
+    complicatedblock.mixed_emitter(1, (7.1, 2.4), 59.1)
+    assert complicatedblock.coords == (7.1, 2.4)
+
 
 
 def test_emitter_receiver_functions(blocks):

--- a/tests/test_pytables.py
+++ b/tests/test_pytables.py
@@ -15,12 +15,12 @@ def newfile(tmpdir):
 
 def test_sink(newfile):
     # mixture of regular Python and numpy dtypes
-    data_format = {
-        'timestamp': float,
-        'trialnum': int,
-        'float32': numpy.float32,
-        'array': numpy.dtype((numpy.float32, (2,)))
-    }
+    data_format = [
+        ('timestamp', float),
+        ('trialnum', int),
+        ('float32', numpy.float32),
+        ('array', numpy.dtype((numpy.float32, (2,))))
+    ]
 
     sink = PyTablesSink(newfile, 'mytable', data_format)
     # ensure a table was created upon creation of the sink


### PR DESCRIPTION
@sixpearls what do you think about this? The underlying `data_format` is a list of 2-tuples, but Python 3.6+ users get the advantage of the nicer syntax.

Note the kwarg syntax works for all versions if an emitter has only one output.