### PR TITLE
Test on python 2.7 and 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,36 @@
-language: bash
+language: python
 os: linux
 sudo: required
 
 python:
-    - "2.7"
-    - "3.4"
+    # - "2.7"
+    # - "3.4"
     - "3.5"
     - "3.6"
 
 install:
     - sudo apt-get update
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-          # python<=3.4
-          MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
-          URL="https://repo.continuum.io/miniconda/"
-          FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
-          wget "${URL}/{FILE}" -O miniconda.sh
-
-          bash miniconda.sh -b -p $HOME/miniconda
-          export PATH="$HOME/miniconda/bin:$PATH"
-          hash -r
-          conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
-          conda info -a
-
-          conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
-          source activate testenv
-      else
-          # python>=3.5
-          pip install -r requirements.txt
-      fi
+      #    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
+      #          # python<=3.4
+      #          MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
+      #          URL="https://repo.continuum.io/miniconda/"
+      #          FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
+      #          wget "${URL}/{FILE}" -O miniconda.sh
+      #
+      #          bash miniconda.sh -b -p $HOME/miniconda
+      #          export PATH="$HOME/miniconda/bin:$PATH"
+      #          hash -r
+      #          conda config --set always_yes yes --set changeps1 no
+      #          conda update -q conda
+      #          conda info -a
+      #
+      #          conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
+      #          source activate testenv
+      #      else
+      #          # python>=3.5
+      #          pip install -r requirements.txt
+      #      fi
+    - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
     - pip install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,15 @@ install:
   - |
     if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       # python<=3.4
-      MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
-      URL="https://repo.continuum.io/miniconda/"
-      FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
-      DEST="{HOME}/miniconda"
+      PYTHON_MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
+      CONDA_URL="https://repo.continuum.io/miniconda/"
+      CONDA_FILE="Miniconda${PYTHON_MAJOR}-latest-Linux-x86_64.sh"
+      CONDA_DEST="{HOME}/miniconda"
 
-      wget "${URL}/{FILE}" -O miniconda.sh
-      bash miniconda.sh -b -p $DEST
+      wget "${CONDA_URL}/{CONDA_FILE}" -O miniconda.sh
+      bash miniconda.sh -b -p $CONDA_DEST
 
-      source $DEST/bin/activate root
+      source $CONDA_DEST/bin/activate root
       conda config --set always_yes yes --set changeps1 no
       conda update -q conda
       conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ install:
     if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       # python<=3.4
       PYTHON_MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
-      CONDA_URL="https://repo.continuum.io/miniconda/"
+      CONDA_URL="https://repo.continuum.io/miniconda"
       CONDA_FILE="Miniconda${PYTHON_MAJOR}-latest-Linux-x86_64.sh"
       CONDA_DEST="{HOME}/miniconda"
 
-      wget "${CONDA_URL}/{CONDA_FILE}" -O miniconda.sh
+      wget $CONDA_URL/$CONDA_FILE -O miniconda.sh
       bash miniconda.sh -b -p $CONDA_DEST
 
       source $CONDA_DEST/bin/activate root

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,26 +10,26 @@ python:
 
 install:
     - sudo apt-get update
-      #    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-      #          # python<=3.4
-      #          MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
-      #          URL="https://repo.continuum.io/miniconda/"
-      #          FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
-      #          wget "${URL}/{FILE}" -O miniconda.sh
-      #
-      #          bash miniconda.sh -b -p $HOME/miniconda
-      #          export PATH="$HOME/miniconda/bin:$PATH"
-      #          hash -r
-      #          conda config --set always_yes yes --set changeps1 no
-      #          conda update -q conda
-      #          conda info -a
-      #
-      #          conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
-      #          source activate testenv
-      #      else
-      #          # python>=3.5
-      #          pip install -r requirements.txt
-      #      fi
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
+          # python<=3.4
+          MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
+          URL="https://repo.continuum.io/miniconda/"
+          FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
+          wget "${URL}/{FILE}" -O miniconda.sh
+
+          bash miniconda.sh -b -p $HOME/miniconda
+          export PATH="$HOME/miniconda/bin:$PATH"
+          hash -r
+          conda config --set always_yes yes --set changeps1 no
+          conda update -q conda
+          conda info -a
+
+          conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
+          source activate testenv
+      else
+          # python>=3.5
+          pip install -r requirements.txt
+      fi
     - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
     - pip install -e .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
+language: generic
+os: linux
 sudo: required
-language: python
 
 python:
     - "2.7"
@@ -9,24 +10,26 @@ python:
 
 install:
     - sudo apt-get update
-    # 
     - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-          wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+          # python<=3.4
+          MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
+          URL="https://repo.continuum.io/miniconda/"
+          FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
+          wget "${URL}/{FILE}" -O miniconda.sh
+
           bash miniconda.sh -b -p $HOME/miniconda
           export PATH="$HOME/miniconda/bin:$PATH"
           hash -r
           conda config --set always_yes yes --set changeps1 no
           conda update -q conda
-
           conda info -a
 
           conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
           source activate testenv
       else
-          # python 3.5+
+          # python>=3.5
           pip install -r requirements.txt
       fi
-    # with 
     - pip install -r requirements-dev.txt
     - pip install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ install:
       conda update -q conda
       conda info -a
 
-      conda env create -f environment.yml -n testenv python="$TRAVIS_PYTHON_VERSION"
+      # create the env in two steps for specific python version
+      conda create -n testenv python="$TRAVIS_PYTHON_VERSION"
       source activate testenv
+      conda env update -n testenv -f environment.yml
     else
       # python>=3.5
       pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,18 @@ install:
       # python<=3.4
       PYTHON_MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
       CONDA_URL="https://repo.continuum.io/miniconda"
-      CONDA_FILE="Miniconda${PYTHON_MAJOR}-latest-Linux-x86_64.sh"
-      CONDA_DEST="{HOME}/miniconda"
+      CONDA_FILE="Miniconda$PYTHON_MAJOR-latest-Linux-x86_64.sh"
+      CONDA_DEST="$HOME/miniconda"
 
-      wget $CONDA_URL/$CONDA_FILE -O miniconda.sh
-      bash miniconda.sh -b -p $CONDA_DEST
+      wget "$CONDA_URL/$CONDA_FILE" -O miniconda.sh
+      bash miniconda.sh -b -p "$CONDA_DEST"
 
-      source $CONDA_DEST/bin/activate root
+      export PATH="$CONDA_DEST/bin:$PATH"
       conda config --set always_yes yes --set changeps1 no
       conda update -q conda
       conda info -a
 
-      conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
+      conda create -q -n testenv python="$TRAVIS_PYTHON_VERSION" -f environment.yml
       source activate testenv
     else
       # python>=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,36 +3,36 @@ os: linux
 sudo: required
 
 python:
-    # - "2.7"
-    # - "3.4"
-    - "3.5"
-    - "3.6"
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 install:
-    - sudo apt-get update
-    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
-          # python<=3.4
-          MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
-          URL="https://repo.continuum.io/miniconda/"
-          FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
-          wget "${URL}/{FILE}" -O miniconda.sh
+  - sudo apt-get update
+  - |
+    if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
+      # python<=3.4
+      MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
+      URL="https://repo.continuum.io/miniconda/"
+      FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
+      wget "${URL}/{FILE}" -O miniconda.sh
 
-          bash miniconda.sh -b -p $HOME/miniconda
-          export PATH="$HOME/miniconda/bin:$PATH"
-          hash -r
-          conda config --set always_yes yes --set changeps1 no
-          conda update -q conda
-          conda info -a
+      bash miniconda.sh -b -p $HOME/miniconda
+      export PATH="$HOME/miniconda/bin:$PATH"
+      hash -r
+      conda config --set always_yes yes --set changeps1 no
+      conda update -q conda
+      conda info -a
 
-          conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
-          source activate testenv
-      else
-          # python>=3.5
-          pip install -r requirements.txt
-      fi
-    - pip install -r requirements.txt
-    - pip install -r requirements-dev.txt
-    - pip install -e .
+      conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
+      source activate testenv
+    else
+      # python>=3.5
+      pip install -r requirements.txt
+    fi
+  - pip install -r requirements-dev.txt
+  - pip install -e .
 
 script:
-    - pytest
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,33 @@ sudo: required
 language: python
 
 python:
+    - "2.7"
+    - "3.4"
     - "3.5"
     - "3.6"
 
 install:
+    - sudo apt-get update
+    # 
+    - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
+          wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+          bash miniconda.sh -b -p $HOME/miniconda
+          export PATH="$HOME/miniconda/bin:$PATH"
+          hash -r
+          conda config --set always_yes yes --set changeps1 no
+          conda update -q conda
+
+          conda info -a
+
+          conda create -q -n testenv python=$TRAVIS_PYTHON_VERSION -f environment.yml
+          source activate testenv
+      else
+          # python 3.5+
+          pip install -r requirements.txt
+      fi
+    # with 
     - pip install -r requirements-dev.txt
     - pip install -e .
 
 script:
-    - python -m pytest -v
+    - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ install:
       MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
       URL="https://repo.continuum.io/miniconda/"
       FILE="Miniconda${MAJOR}-latest-Linux-x86_64.sh"
-      wget "${URL}/{FILE}" -O miniconda.sh
+      DEST="{HOME}/miniconda"
 
-      bash miniconda.sh -b -p $HOME/miniconda
-      export PATH="$HOME/miniconda/bin:$PATH"
-      hash -r
+      wget "${URL}/{FILE}" -O miniconda.sh
+      bash miniconda.sh -b -p $DEST
+
+      source $DEST/bin/activate root
       conda config --set always_yes yes --set changeps1 no
       conda update -q conda
       conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ install:
   - |
     if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]] || [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       # python<=3.4
-      PYTHON_MAJOR="${TRAVIS_PYTHON_VERSION:0:1}"
       CONDA_URL="https://repo.continuum.io/miniconda"
-      CONDA_FILE="Miniconda$PYTHON_MAJOR-latest-Linux-x86_64.sh"
+      CONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
       CONDA_DEST="$HOME/miniconda"
 
       wget "$CONDA_URL/$CONDA_FILE" -O miniconda.sh
@@ -26,7 +25,7 @@ install:
       conda update -q conda
       conda info -a
 
-      conda create -q -n testenv python="$TRAVIS_PYTHON_VERSION" -f environment.yml
+      conda env create -f environment.yml -n testenv python="$TRAVIS_PYTHON_VERSION"
       source activate testenv
     else
       # python>=3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: generic
+language: bash
 os: linux
 sudo: required
 

--- a/axopy/storage.py
+++ b/axopy/storage.py
@@ -105,7 +105,7 @@ class Storage(object):
 
         try:
             makedirs(path)
-        except FileExistsError:
+        except OSError:
             raise ValueError(
                 "Subject {} has already started \"{}\". Only unique task "
                 "names are allowed.".format(self.subject_id, task_id))

--- a/axopy/timing.py
+++ b/axopy/timing.py
@@ -1,5 +1,6 @@
 """Utilities for keeping track of time in a task."""
 
+from __future__ import division
 from PyQt5 import QtCore
 from axopy.messaging import transmitter, receiver
 

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,6 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - python
     - numpy
     - scipy
     - pandas

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,12 @@
+name: axopy
+channels:
+    - conda-forge
+    - defaults
+dependencies:
+    - python
+    - numpy
+    - scipy
+    - pandas
+    - h5py
+    - pyqt>=5
+    - pyqtgraph>=0.10

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 pytest
 pytest-cov
 pytest-qt

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,23 @@
+import os
 from setuptools import setup, find_packages
 
 
 def readme():
     with open('README.rst') as f:
         return f.read()
+
+
+install_requires = [
+    'numpy',
+    'scipy',
+    'pandas',
+    'h5py',
+    'pyqtgraph'
+]
+# add pyqt5 to requirements for pip installs only
+# conda will complain because its package is just called "pyqt"
+if "CONDA_PREFIX" not in os.environ:
+    install_requires.append('pyqt5')
 
 
 setup(
@@ -35,14 +49,5 @@ setup(
 
     packages=find_packages(),
 
-    install_requires=[
-        'numpy',
-        'scipy',
-        'pandas',
-        'h5py',
-        'pyqt5',
-        'pyqtgraph'
-    ],
-
-    extras_require={}
+    install_requires=install_requires,
 )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,7 +13,7 @@ rand_data_1d = np.random.rand(100)
 rand_data_2d1 = np.random.rand(1, 100)
 rand_data_2d = np.random.rand(5, 100)
 
-b, a = signal.butter(2, (10/1000, 450/1000), btype='bandpass')
+b, a = signal.butter(2, (10/1000., 450/1000.), btype='bandpass')
 
 
 #


### PR DESCRIPTION
For Python versions before 3.5, installing via pip doesn't seem like it will ever be feasible because PyQt5 isn't building wheels for them. Conda should work, though, and I'd prefer to keep compatible with Python 2 for as long as possible. There were *two* things to fix to get running on Python 2.