### PR TITLE
Task design

### DIFF
--- a/axopy/design.py
+++ b/axopy/design.py
@@ -127,7 +127,7 @@ class Trial(object):
         kwargs : dict
             Keyword arguments passed along to :class:`Array`.
         """
-        self.arrays[name] = Array(data=data, stack_axis=stack_axis)
+        self.arrays[name] = Array(**kwargs)
 
     def __repr__(self):
         return str(self.attrs) + '\n' + str(self.arrays)

--- a/axopy/design.py
+++ b/axopy/design.py
@@ -1,62 +1,187 @@
+"""Task design containers."""
 import numpy
 import random
 
+__all__ = ['Design', 'Block', 'Trial', 'Array']
+
 
 class Design(list):
+    """Top-level task design container.
+
+    The :class:`Design` is a list of :class:`Block` objects, which themselves
+    are lists of :class:`Trial` objects.
+    """
 
     def add_block(self):
-        b = Block(len(self))
-        self.append(b)
-        return b
+        """Add a block to the design.
+
+        Returns
+        -------
+        block : design.Block
+            The created block.
+        """
+        block = Block(len(self))
+        self.append(block)
+        return block
 
 
 class Block(list):
+    """List of trials.
+
+    Experiments often consist of a set of blocks, each containing the same set
+    of trials in randomized order. You usually shouldn't need to create a block
+    directly -- use :meth:`Design.add_block` instead.
+
+    Parameters
+    ----------
+    index : int
+        Index of the block in the design. This is required to pass along to
+        each trial in the block, so that the trial knows which block it belongs
+        to.
+    """
 
     def __init__(self, index, *args, **kwargs):
         super(Block, self).__init__(*args, **kwargs)
         self.index = index
 
     def add_trial(self, attrs=None):
+        """Add a trial to the block.
+
+        A :class:`Trial` object is created and added to the block. You can
+        optionally provide a dictionary of attribute name/value pairs to
+        initialize the trial.
+
+        Parameters
+        ----------
+        attrs : dict, optional
+            Dictionary of attribute name/value pairs.
+
+        Returns
+        -------
+        trial : Trial
+            The trial object created. This can be used to add new attributes or
+            arrays. See :class:`Trial`.
+        """
         if attrs is None:
             attrs = {}
 
         attrs.update({'block': self.index, 'trial': len(self)})
 
-        t = Trial(attrs=attrs)
-        self.append(t)
-        return t
+        trial = Trial(attrs=attrs)
+        self.append(trial)
+        return trial
 
-    def shuffle(self):
+    def shuffle(self, reset_index=True):
+        """Shuffle the block's trials in random order.
+
+        Parameters
+        ----------
+        reset_index : bool, optional
+            Whether or not to set the ``trial`` attribute of each trial such
+            that they remain in sequential order after shuffling. This is the
+            default.
+        """
         random.shuffle(self)
+        if reset_index:
+            for i, trial in enumerate(self):
+                trial.attrs['trial'] = i
 
 
 class Trial(object):
+    """Container of trial data.
+
+    There are two kinds of data typically needed during a trial: attributes and
+    arrays. Attributes are scalar quantities or primitives like integers,
+    floating point numbers, booleans, strings, etc. Arrays are NumPy arrays,
+    useful for holding things like cursor trajectories.
+
+    There are two primary purposes for each of these two kinds of data. First,
+    it's useful to design a task with pre-determined values, such as the target
+    location or the cursor trajectory to follow. The other purpose is to
+    temporarily hold runtime data using the same interface, such as the final
+    cursor position or the time-to-target.
+
+    You shouldn't normally need to create a trial directly -- instead, use
+    :meth:`Block.add_trial`.
+
+    Attributes
+    ----------
+    attrs : dict
+        Dictionary mapping attribute names to their values.
+    arrays : dict
+        Dictionary mapping array names to :class:`Array` objects, which contain
+        the array data.
+    """
 
     def __init__(self, attrs):
         self.attrs = attrs
         self.arrays = {}
 
-    def add_array(self, name, data=None, orientation='horizontal'):
-        self.arrays[name] = Array(data=data, orientation=orientation)
+    def add_array(self, name, **kwargs):
+        """Add an array to the trial.
+
+        Parameters
+        ----------
+        name : str
+            Name of the array.
+        kwargs : dict
+            Keyword arguments passed along to :class:`Array`.
+        """
+        self.arrays[name] = Array(data=data, stack_axis=stack_axis)
 
     def __repr__(self):
         return str(self.attrs) + '\n' + str(self.arrays)
 
 
 class Array(object):
+    """Trial array.
 
-    def __init__(self, data=None, orientation='horizontal'):
-        self.orientation = orientation
+    The array is not much more than a NumPy array with a :meth:`stack` method
+    for conveniently adding new data to the array. This is useful in cases
+    where you iteratively collect new segments of data and want to concatenate
+    them. For example, you could use an :class:`Array` to collect the samples
+    from a data acquisition device as they come in.
+
+    You usually don't need to create an array manually -- instead, use
+    :meth:`Trial.add_array`.
+
+    Parameters
+    ----------
+    data : ndarray, optional
+        Data to initialize the array with. If ``None``, the first array passed
+        to :meth:`stack` is used for initialization.
+    stack_axis : int, optional
+        Axis to stack the data along.
+
+    Attributes
+    ----------
+    data : ndarray, optional
+        The NumPy array holding the data.
+    """
+
+    _stack_funcs = {0: numpy.vstack, 1: numpy.hstack, 2: numpy.dstack}
+
+    def __init__(self, data=None, stack_axis=1):
         self.data = data
+        self.stack_axis = stack_axis
 
     def stack(self, data):
+        """Stack new data onto the array.
+
+        Parameters
+        ----------
+        data : ndarray
+            New data to add. The direction to stack along is specified in the
+            array's constructor (stack_axis).
+        """
         if self.data is None:
             self.data = data
         else:
-            if self.orientation == 'vertical':
-                self.data = numpy.vstack([self.data, data])
-            else:
-                self.data = numpy.hstack([self.data, data])
+            self.data = self._stack_funcs[self.stack_axis]([self.data, data])
 
     def clear(self):
+        """Clears the buffer.
+
+        Anything that was in the buffer is not retrievable.
+        """
         self.data = None

--- a/axopy/design.py
+++ b/axopy/design.py
@@ -1,0 +1,62 @@
+import numpy
+import random
+
+
+class Design(list):
+
+    def add_block(self):
+        b = Block(len(self))
+        self.append(b)
+        return b
+
+
+class Block(list):
+
+    def __init__(self, index, *args, **kwargs):
+        super(Block, self).__init__(*args, **kwargs)
+        self.index = index
+
+    def add_trial(self, attrs=None):
+        if attrs is None:
+            attrs = {}
+
+        attrs.update({'block': self.index, 'trial': len(self)})
+
+        t = Trial(attrs=attrs)
+        self.append(t)
+        return t
+
+    def shuffle(self):
+        random.shuffle(self)
+
+
+class Trial(object):
+
+    def __init__(self, attrs):
+        self.attrs = attrs
+        self.arrays = {}
+
+    def add_array(self, name, data=None, orientation='horizontal'):
+        self.arrays[name] = Array(data=data, orientation=orientation)
+
+    def __repr__(self):
+        return str(self.attrs) + '\n' + str(self.arrays)
+
+
+class Array(object):
+
+    def __init__(self, data=None, orientation='horizontal'):
+        self.orientation = orientation
+        self.data = data
+
+    def stack(self, data):
+        if self.data is None:
+            self.data = data
+        else:
+            if self.orientation == 'vertical':
+                self.data = numpy.vstack([self.data, data])
+            else:
+                self.data = numpy.hstack([self.data, data])
+
+    def clear(self):
+        self.data = None

--- a/axopy/task/base.py
+++ b/axopy/task/base.py
@@ -229,38 +229,14 @@ class _TaskIter(object):
     """Cleanly retrieves blocks of a task design and the trials within them.
 
     A task design is a sequence of sequences: a sequence of blocks which are
-    themselves sequences of trials. The `TaskIter` iterates over blocks,
+    themselves sequences of trials. The ``TaskIter`` iterates over blocks,
     returning the block data when a new block is available. Nested in the
-    blocks are trials, which the `TaskIter` further iterates over, returning
+    blocks are trials, which the ``TaskIter`` further iterates over, returning
     them when available.
 
-    Here is more graphical depiction of the flow through a design::
-
-        design: [
-            next_block -> block: [
-                next_trial -> trial,
-                next_trial -> trial,
-                ...
-                next_trial -> None
-            ],
-            next_block -> block: [
-                next_trial -> trial,
-                next_trial -> trial,
-                ...
-                next_trial -> None
-            ],
-            ...
-            next_block -> None
-        ]
-
-    Parameters
-    ----------
-    design : list
-        The task `design` must be an iterable of iterables, such as a list of
-        lists. The elements of the outer iterable are termed "blocks" and the
-        elements of the inner iterable are termed "trials." The trials have any
-        structure you want, but a typical choice would be a dictionary with
-        attributes that specify all parameters of the trial.
+    The ``TaskIter`` accepts either a :class:`axopy.design.Design`` or a
+    manually-created list of blocks, where each block is a list containing
+    dictionaries corresponding to trials.
     """
 
     def __init__(self, design):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,7 @@ These are the modules/subpackages which constitute AxoPy.
 
    api/experiment
    api/task
+   api/design
    api/pipeline
    api/features
    api/messaging

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -1,45 +1,39 @@
 import numpy as np
 from axopy import design
 
-d = design.Design()
-b = d.add_block()
-t = b.add_trial(attrs={'attr': 0})
-t.attrs['var'] = True
-t.add_array('static', data=np.random.randn(100))
-t.add_array('dynamic')
-for i in range(10):
-    t.arrays['dynamic'].stack(np.random.randn(5))
 
-# class CustomTask(Task):
-# 
-#     def setup_design(self, design):
-#         for i in range(10):
-#             block = design.add_block()
-#             for j in range(10):
-#                 # can set trial attributes optionally
-#                 trial = block.add_trial(
-#                     attrs={
-#                         'target_x': j,
-#                         'target_y': j
-#                     }
-#                 )
-#                 # can add/reset attrs at any time
-#                 trial.attrs['extra'] = 0
-# 
-#                 # add array with data already in it
-#                 trial.add_array('random', data=np.random.randn(100))
-# 
-#                 # add an empty array
-#                 trial.add_array('cursor')
-# 
-#             block.shuffle()
-# 
-#     def update(self, data):
-#         # stack data in a trial array
-#         self.trial.arrays['cursor'].stack(data)
-# 
-#     def finish_trial(self):
-#         # set a trial attribute
-#         self.trial.attrs['extra'] = 1
-# 
-#         self.storage.write(self.trial)
+def test_design():
+    d = design.Design()
+    b = d.add_block()
+
+    # add trial with attributes as args
+    t = b.add_trial(attrs={'attr': 1.0})
+    # set trial attributes later
+    t.attrs['var'] = True
+    assert set(t.attrs) == set({'trial': 0, 'block': 0, 'attr': 1.0,
+                                'var': True})
+
+    # add an empty array
+    t.add_array('1d')
+    for i in range(3):
+        t.arrays['1d'].stack(np.zeros(5))
+    assert t.arrays['1d'].data.shape == (15,)
+
+    t.add_array('2d')
+    for i in range(3):
+        t.arrays['2d'].stack(np.zeros((2, 5)))
+    assert t.arrays['2d'].data.shape == (2, 15)
+
+    t.add_array('static', data=np.random.randn(100))
+
+
+def test_block_shuffle():
+    d = design.Design()
+    b = d.add_block()
+
+    for i in range(10):
+        b.add_trial()
+
+    for i in range(10):
+        b.shuffle()
+        assert b[0].attrs['trial'] == 0

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -1,0 +1,45 @@
+import numpy as np
+from axopy import design
+
+d = design.Design()
+b = d.add_block()
+t = b.add_trial(attrs={'attr': 0})
+t.attrs['var'] = True
+t.add_array('static', data=np.random.randn(100))
+t.add_array('dynamic')
+for i in range(10):
+    t.arrays['dynamic'].stack(np.random.randn(5))
+
+# class CustomTask(Task):
+# 
+#     def setup_design(self, design):
+#         for i in range(10):
+#             block = design.add_block()
+#             for j in range(10):
+#                 # can set trial attributes optionally
+#                 trial = block.add_trial(
+#                     attrs={
+#                         'target_x': j,
+#                         'target_y': j
+#                     }
+#                 )
+#                 # can add/reset attrs at any time
+#                 trial.attrs['extra'] = 0
+# 
+#                 # add array with data already in it
+#                 trial.add_array('random', data=np.random.randn(100))
+# 
+#                 # add an empty array
+#                 trial.add_array('cursor')
+# 
+#             block.shuffle()
+# 
+#     def update(self, data):
+#         # stack data in a trial array
+#         self.trial.arrays['cursor'].stack(data)
+# 
+#     def finish_trial(self):
+#         # set a trial attribute
+#         self.trial.attrs['extra'] = 1
+# 
+#         self.storage.write(self.trial)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -14,14 +14,6 @@ def simple_design():
     return design
 
 
-def test_empty_design():
-    it = _TaskIter()
-    assert it.next_block() is not None
-    assert it.next_trial() is not None
-    assert it.next_block() is None
-    assert it.next_trial() is None
-
-
 def test_task_iter(simple_design):
     d = simple_design
 
@@ -43,27 +35,31 @@ def test_task_iter(simple_design):
 
 def test_base_task(simple_design):
     task = Task()
-    task.design(simple_design)
 
-    # task prepare hooks
+    for b in range(2):
+        block = task.iter.design.add_block()
+        for t in range(2):
+            block.add_trial()
+
+    # task prepare hooks run by Experiment
     task.prepare_view(None)
     task.prepare_input_stream(None)
     task.prepare_storage(None)
 
     task.run()
-    assert task.block == simple_design[0]
+    assert task.block.index == 0
     # task is waiting for key press to advance
     assert not hasattr(task, 'trial')
     task.key_press(util.key_return)
-    assert task.trial == simple_design[0][0]
+    assert task.trial.attrs == simple_design[0][0]
 
     # automatically advance to next block
     task.advance_block_key = None
     task.next_trial()
     task.next_trial()
 
-    assert task.block == simple_design[1]
-    assert task.trial == simple_design[1][0]
+    assert task.block.index == 1
+    assert task.trial.attrs == simple_design[1][0]
 
     class recv(object):
         def finish(self):


### PR DESCRIPTION
Implementation of a bridge between tasks and storage. The goal here is to standardize task design (currently, it's just: "design is a list of lists of dictionaries"), make it possible to specify how the entire task dataset is laid out, and provide a `storage.write(trial)` method that can just dump the trial design data all at once.

- [x] create the base task design hierarchy (design -> block -> trial -> array)
- [x] add some unit tests
- [x] integrate into Task
- ~[ ] use abstract base classes from collections~
- ~[ ] make `Trial` a dict so trial attrs can be accessed directly~